### PR TITLE
Support libxposed API 102 and HyperOS 4

### DIFF
--- a/MiAOSPIME/build.gradle
+++ b/MiAOSPIME/build.gradle
@@ -3,12 +3,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 36
+    compileSdkVersion 37
 
     defaultConfig {
         applicationId namespace
         minSdkVersion 34
-        targetSdkVersion 36
+        targetSdkVersion 37
         versionCode rootProject.ext.commitCount
         versionName "1.2.0"
     }
@@ -79,25 +79,23 @@ base {
     archivesName = project.name + "-" + android.defaultConfig.versionName + "." + android.defaultConfig.versionCode
 }
 dependencies {
-    implementation "androidx.annotation:annotation:1.9.1"
-    compileOnly 'io.github.libxposed:api:101.0.0'
+    implementation "androidx.annotation:annotation:1.10.0"
+    compileOnly 'io.github.libxposed:api:102.0.0'
     compileOnly project(":hiddenapi:stubs")
     implementation project(":hiddenapi:bridge")
-    implementation 'io.github.libxposed:service:101.0.0'
+    implementation 'io.github.libxposed:service:102.0.0'
 }
 
-tasks.register('applyXposedDebug', Exec) {
+tasks.register('applyXposedDebug') {
     group "xposed"
     dependsOn "installDebug"
-    commandLine "adb", "shell", "svc", "power", "reboot"
-    ignoreExitValue = true
+    description "Install the debug APK and let LSPosed API 102 hot reload the module."
 }
 
-tasks.register('applyXposedRelease', Exec) {
+tasks.register('applyXposedRelease') {
     group "xposed"
     dependsOn "installRelease"
-    commandLine "adb", "shell", "svc", "power", "reboot"
-    ignoreExitValue = true
+    description "Install the release APK and let LSPosed API 102 hot reload the module."
 }
 
 tasks.register('applyXposedImeDebug', Exec) {

--- a/MiAOSPIME/src/main/java/io/github/howard20181/ime/ImeHook.java
+++ b/MiAOSPIME/src/main/java/io/github/howard20181/ime/ImeHook.java
@@ -2,8 +2,10 @@ package io.github.howard20181.ime;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.om.OverlayManager;
 import android.content.res.Resources;
+import android.graphics.Insets;
 import android.inputmethodservice.InputMethodService;
 import android.os.Build;
 import android.provider.Settings;
@@ -11,39 +13,100 @@ import android.util.Log;
 import android.util.TypedValue;
 import android.view.RoundedCorner;
 import android.view.View;
+import android.view.WindowInsets;
 import android.view.inputmethod.InputMethodManager;
 
 import androidx.annotation.NonNull;
 
-import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import bridge.HiddenApiBridge;
+import io.github.libxposed.api.XposedInterface;
 import io.github.libxposed.api.XposedModule;
+import io.github.libxposed.api.XposedModuleInterface;
 
 @SuppressLint({"PrivateApi", "BlockedPrivateApi", "SoonBlockedPrivateApi"})
 public class ImeHook extends XposedModule {
     private static final String TAG = "ImeHook";
-    private static XposedModule module;
+    private static final String HOOK_HIDE_GESTURAL_BUTTONS = "ime_hide_gestural_buttons";
+    private static final String HOOK_CAPTION_BAR_HEIGHT = "ime_caption_bar_height";
+    private static final String HOOK_CAPTION_BAR_INSETS_HEIGHT =
+            "ime_caption_bar_insets_height";
+    private static final String HOOK_SYSTEM_INSETS_HEIGHT = "ime_system_insets_height";
+    private static final String HOOK_INPUT_VIEW_BOTTOM_INSET = "ime_input_view_bottom_inset";
+    private static final String HOOK_DISPATCH_INPUT_VIEW_INSETS =
+            "ime_dispatch_input_view_insets";
+    private static final String HOOK_INFLATE_NAV_LAYOUT = "ime_inflate_nav_layout";
+    private static final String HOOK_UPDATE_ORIENTATION = "ime_update_orientation";
+    private static final String HOOK_DEAD_ZONE = "ime_dead_zone";
+    private static final String HOOK_NAV_BUTTON_FLAGS = "server_ime_nav_button_flags";
+    private static final String HOOK_CUSTOM_IME_CALLER = "server_custom_ime_caller";
+    private static final String HOOK_LOAD_BOTTOM_DEX = "ime_load_bottom_dex";
+    private static final String HOOK_SUPPORTED_IME_LIST = "ime_supported_ime_list";
+
+    private final List<XposedInterface.HookHandle> hookHandles = new ArrayList<>();
+    private final AtomicReference<String> navBarLayoutHandle = new AtomicReference<>("");
+    private SharedPreferences navBarPreferences;
+    private SharedPreferences.OnSharedPreferenceChangeListener navBarPreferenceListener;
 
     @Override
-    public void onModuleLoaded(@NonNull ModuleLoadedParam param) {
-        module = this;
+    public boolean onHotReloading(XposedModuleInterface.HotReloadingParam param) {
+        releaseNavBarLayoutPreferences();
+        log(Log.INFO, TAG, "Hot reloading with " + hookHandles.size() + " hooks");
+        return true;
+    }
+
+    @Override
+    public void onHotReloaded(XposedModuleInterface.HotReloadedParam param) {
+        boolean needsNavBarPreferences = false;
+        int replaced = 0;
+        ClassLoader targetClassLoader = null;
+        Set<String> installedHookIds = new HashSet<>();
+        for (XposedInterface.HookHandle oldHandle : param.getOldHookHandles()) {
+            try {
+                if (targetClassLoader == null && oldHandle.getExecutable() != null) {
+                    targetClassLoader = oldHandle.getExecutable().getDeclaringClass().getClassLoader();
+                }
+                String hookId = oldHandle.getId();
+                if (hookId == null || hookId.isBlank()) {
+                    hookId = identifyHook(oldHandle.getExecutable());
+                }
+                XposedInterface.Hooker replacement = createHotReloadHooker(hookId);
+                if (replacement == null) {
+                    oldHandle.unhook();
+                    continue;
+                }
+                recordHookHandle(oldHandle.replaceHook(replacement));
+                replaced++;
+                installedHookIds.add(hookId);
+                needsNavBarPreferences |= HOOK_INFLATE_NAV_LAYOUT.equals(hookId);
+            } catch (Throwable throwable) {
+                log(Log.ERROR, TAG, "replace hook while hot reloading", throwable);
+            }
+        }
+        if (needsNavBarPreferences) {
+            initializeNavBarLayoutPreferences();
+        }
+        backfillHotReloadHooks(param, targetClassLoader, installedHookIds);
+        log(Log.INFO, TAG, "Hot reload completed with " + replaced + " hooks");
     }
 
     @Override
     public void onSystemServerStarting(@NonNull SystemServerStartingParam param) {
         var classLoader = param.getClassLoader();
         try {
-            if (Build.VERSION.SDK_INT == Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                try {
-                    hookInputMethodManagerService(classLoader);
-                } catch (Exception e) {
-                    log(Log.ERROR, TAG, "hook InputMethodManagerService", e);
-                }
+            try {
+                hookInputMethodManagerService(classLoader);
+            } catch (Exception e) {
+                log(Log.ERROR, TAG, "hook InputMethodManagerService", e);
             }
             try {
                 hookInputMethodManagerServiceImpl(classLoader);
@@ -67,9 +130,29 @@ public class ImeHook extends XposedModule {
                 log(Log.ERROR, TAG, "hook InputMethodService", e);
             }
             try {
+                hookInputViewBottomInset(classLoader);
+            } catch (Exception e) {
+                log(Log.ERROR, TAG, "hook InputMethodService.setInputView", e);
+            }
+            try {
+                hookInputViewInsetsDispatch(classLoader);
+            } catch (Exception e) {
+                log(Log.ERROR, TAG, "hook View.dispatchApplyWindowInsets", e);
+            }
+            try {
                 hookNavigationBarController(classLoader);
             } catch (Exception e) {
                 log(Log.ERROR, TAG, "hook NavigationBarController", e);
+            }
+            try {
+                hookCaptionBarInsetsHeight(classLoader);
+            } catch (Exception e) {
+                log(Log.ERROR, TAG, "hook InsetsController.setImeCaptionBarInsetsHeight", e);
+            }
+            try {
+                hookNavigationBarSystemInsets(classLoader);
+            } catch (Exception e) {
+                log(Log.ERROR, TAG, "hook NavigationBarController.getSystemInsets", e);
             }
             try {
                 hookNavigationBarInflaterView(classLoader);
@@ -100,42 +183,19 @@ public class ImeHook extends XposedModule {
             ClassNotFoundException {
         var classInputMethodService = classLoader.loadClass("android.inputmethodservice.InputMethodService");
         try {
-            var fieldIsInternationalBuild = classInputMethodService.getDeclaredField("IS_INTERNATIONAL_BUILD");
-            fieldIsInternationalBuild.setAccessible(true);
+            classInputMethodService.getDeclaredField("IS_INTERNATIONAL_BUILD");
             var methodHideImeRenderGesturalNavButtons = classInputMethodService.getDeclaredMethod("hideImeRenderGesturalNavButtons", String.class);
-            hook(methodHideImeRenderGesturalNavButtons).intercept(chain -> {
-                try {
-                    var classInputMethodServiceStub = classLoader.loadClass("android.inputmethodservice.InputMethodServiceStub");
-                    var methodInputMethodServiceStubGetInstance = classInputMethodServiceStub.getDeclaredMethod("getInstance");
-                    var InputMethodServiceInjector = getInvoker(methodInputMethodServiceStubGetInstance).invoke(chain.getThisObject());
-                    if (InputMethodServiceInjector != null) {
-                        var methodIsImeSupport = InputMethodServiceInjector.getClass().getDeclaredMethod("isImeSupport", Context.class);
-                        methodIsImeSupport.setAccessible(true);
-                        if (chain.getThisObject() instanceof InputMethodService inputMethodService) {
-                            if (getInvoker(methodIsImeSupport).invoke(InputMethodServiceInjector,
-                                    inputMethodService.getApplicationContext()) instanceof Boolean isImeSupport && !isImeSupport) {
-                                fieldIsInternationalBuild.setBoolean(chain.getThisObject(), true);
-                            }
-                        }
-                    }
-                } catch (IllegalAccessException | InvocationTargetException |
-                         NoSuchMethodException | ClassNotFoundException e) {
-                    log(Log.ERROR, TAG, "hook hideImeRenderGesturalNavButtons", e);
-                }
-                return chain.proceed();
-            });
+            recordHookHandle(hook(methodHideImeRenderGesturalNavButtons)
+                    .setId(HOOK_HIDE_GESTURAL_BUTTONS)
+                    .intercept(this::interceptHideGesturalButtons));
         } catch (NoSuchFieldException e) {
             log(Log.WARN, TAG, "IS_INTERNATIONAL_BUILD not found", e);
         }
     }
 
     private void hookNavigationBarController(ClassLoader classLoader) throws
-            ClassNotFoundException, NoSuchFieldException {
-        var classNavigationBarController$Impl = classLoader.loadClass("android.inputmethodservice.NavigationBarController$Impl");
-        var mImeDrawsImeNavBar = classNavigationBarController$Impl.getDeclaredField("mImeDrawsImeNavBar");
-        mImeDrawsImeNavBar.setAccessible(true);
-        var mInputMethodService = classNavigationBarController$Impl.getDeclaredField("mService");
-        mInputMethodService.setAccessible(true);
+            ClassNotFoundException {
+        Class<?> classNavigationBarController$Impl = loadNavigationBarControllerClass(classLoader);
         try {
             Method getImeCaptionBarHeight;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
@@ -143,108 +203,94 @@ public class ImeHook extends XposedModule {
             } else {
                 getImeCaptionBarHeight = classNavigationBarController$Impl.getDeclaredMethod("getImeCaptionBarHeight");
             }
-            hook(getImeCaptionBarHeight).intercept(chain -> {
-                try {
-                    boolean imeShouldShowImeNavBar;
-                    if (!chain.getArgs().isEmpty() && chain.getArgs().get(0) instanceof Boolean imeDrawsImeNavBar) {
-                        imeShouldShowImeNavBar = imeDrawsImeNavBar;
-                    } else {
-                        imeShouldShowImeNavBar = mImeDrawsImeNavBar.getBoolean(chain.getThisObject());
-                    }
-                    if (imeShouldShowImeNavBar) {
-                        var mService = mInputMethodService.get(chain.getThisObject());
-                        if (mService instanceof InputMethodService inputMethodService) {
-                            return dpToPx(48, inputMethodService.getResources());
-                        }
-                    }
-                } catch (IllegalAccessException e) {
-                    log(Log.ERROR, TAG, "hook getImeCaptionBarHeight", e);
-                }
-                return chain.proceed();
-            });
+            recordHookHandle(hook(getImeCaptionBarHeight)
+                    .setId(HOOK_CAPTION_BAR_HEIGHT)
+                    .intercept(this::interceptCaptionBarHeight));
         } catch (NoSuchMethodException e) {
             log(Log.WARN, TAG, "getImeCaptionBarHeight method not found", e);
         }
+    }
+
+    private void hookInputViewBottomInset(ClassLoader classLoader) throws Exception {
+        if (!usesStandaloneNavigationBarController(classLoader)) return;
+        Class<?> inputMethodService = classLoader.loadClass(
+                "android.inputmethodservice.InputMethodService");
+        Method setInputView = inputMethodService.getDeclaredMethod("setInputView", View.class);
+        recordHookHandle(hook(setInputView).setId(HOOK_INPUT_VIEW_BOTTOM_INSET)
+                .intercept(this::interceptInputViewBottomInset));
+    }
+
+    private void hookCaptionBarInsetsHeight(ClassLoader classLoader) throws Exception {
+        if (!usesStandaloneNavigationBarController(classLoader)) return;
+        Class<?> insetsController = classLoader.loadClass("android.view.InsetsController");
+        Method setter = insetsController.getDeclaredMethod("setImeCaptionBarInsetsHeight",
+                int.class);
+        recordHookHandle(hook(setter).setId(HOOK_CAPTION_BAR_INSETS_HEIGHT)
+                .intercept(this::interceptCaptionBarInsetsHeight));
+    }
+
+    private void hookInputViewInsetsDispatch(ClassLoader classLoader) throws Exception {
+        if (!usesStandaloneNavigationBarController(classLoader)) return;
+        Class<?> viewClass = classLoader.loadClass("android.view.View");
+        Method dispatchInsets = viewClass.getDeclaredMethod("dispatchApplyWindowInsets",
+                WindowInsets.class);
+        recordHookHandle(hook(dispatchInsets).setId(HOOK_DISPATCH_INPUT_VIEW_INSETS)
+                .intercept(this::interceptInputViewInsetsDispatch));
+    }
+
+    private void hookNavigationBarSystemInsets(ClassLoader classLoader) throws Exception {
+        Class<?> controllerClass = loadNavigationBarControllerClass(classLoader);
+        if (!"android.inputmethodservice.NavigationBarController".equals(
+                controllerClass.getName())) {
+            return;
+        }
+        Method getSystemInsets = controllerClass.getDeclaredMethod("getSystemInsets");
+        recordHookHandle(hook(getSystemInsets).setId(HOOK_SYSTEM_INSETS_HEIGHT)
+                .intercept(this::interceptNavigationBarSystemInsets));
+    }
+
+    private Class<?> loadNavigationBarControllerClass(ClassLoader classLoader)
+            throws ClassNotFoundException {
+        try {
+            return classLoader.loadClass("android.inputmethodservice.NavigationBarController$Impl");
+        } catch (ClassNotFoundException ignored) {
+            return classLoader.loadClass("android.inputmethodservice.NavigationBarController");
+        }
+    }
+
+    private boolean usesStandaloneNavigationBarController(ClassLoader classLoader)
+            throws ClassNotFoundException {
+        return "android.inputmethodservice.NavigationBarController".equals(
+                loadNavigationBarControllerClass(classLoader).getName());
     }
 
     private void hookNavigationBarInflaterView(ClassLoader classLoader) throws NoSuchMethodException,
             ClassNotFoundException {
         var classNavigationBarInflaterView = classLoader.loadClass("android.inputmethodservice.navigationbar.NavigationBarInflaterView");
         var methodInflateLayout = classNavigationBarInflaterView.getDeclaredMethod("inflateLayout", String.class);
-        var prefs = getRemotePreferences("conf");
-        AtomicReference<String> config_navBarLayoutHandle = new AtomicReference<>(prefs.getString("nav_bar_layout_handle", ""));
-        prefs.registerOnSharedPreferenceChangeListener((sharedPreferences, key) -> {
-            if ("nav_bar_layout_handle".equals(key)) {
-                config_navBarLayoutHandle.set(sharedPreferences.getString(key, ""));
-            }
-        });
-        hook(methodInflateLayout).intercept(chain -> {
-            if (chain.getArgs().get(0) instanceof String && !config_navBarLayoutHandle.get().isBlank()) {
-                var args = chain.getArgs().toArray();
-                args[0] = config_navBarLayoutHandle.get();
-                return chain.proceed(args);
-            }
-            return chain.proceed();
-        });
+        initializeNavBarLayoutPreferences();
+        recordHookHandle(hook(methodInflateLayout).setId(HOOK_INFLATE_NAV_LAYOUT)
+                .intercept(this::interceptInflateNavLayout));
     }
 
     private static final WeakHashMap<View, int[]> BASE_PADDINGS = new WeakHashMap<>();
+    private static final WeakHashMap<View, String> ACTIVE_NAV_BAR_LAYOUTS =
+            new WeakHashMap<>();
 
     private void hookNavigationBarView(ClassLoader classLoader) throws NoSuchMethodException,
-            ClassNotFoundException, NoSuchFieldException {
+            ClassNotFoundException {
         var classNavigationBarView = classLoader.loadClass("android.inputmethodservice.navigationbar.NavigationBarView");
         var updateOrientationViews = classNavigationBarView.getDeclaredMethod("updateOrientationViews");
-        var fHorizontal = classNavigationBarView.getDeclaredField("mHorizontal");
-        fHorizontal.setAccessible(true);
-        hook(updateOrientationViews).intercept(chain -> {
-            var result = chain.proceed();
-            var obj = chain.getThisObject();
-            if (obj == null) return result;
-            try {
-                if (fHorizontal.get(obj) instanceof View horizontalView) {
-                    var shadow = dpToPx(4, horizontalView.getResources());
-                    horizontalView.setOnApplyWindowInsetsListener((v, insets) -> {
-                        var basePadding = BASE_PADDINGS.computeIfAbsent(v, x -> new int[]{
-                                x.getPaddingLeft() + shadow,
-                                x.getPaddingTop(),
-                                x.getPaddingRight() + shadow,
-                                x.getPaddingBottom()
-                        });
-                        var bottomLeft = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT);
-                        var bottomRight = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT);
-                        int radiusBottomLeft = bottomLeft != null ? bottomLeft.getRadius() : 0;
-                        int radiusBottomRight = bottomRight != null ? bottomRight.getRadius() : 0;
-                        v.setPadding(radiusBottomLeft > 0 ? radiusBottomLeft - basePadding[0] : basePadding[0],
-                                basePadding[1],
-                                radiusBottomRight > 0 ? radiusBottomRight - basePadding[2] : basePadding[2],
-                                basePadding[3]);
-                        return insets;
-                    });
-                }
-            } catch (IllegalAccessException e) {
-                log(Log.ERROR, TAG, "hook updateOrientationViews", e);
-            }
-            return result;
-        });
+        recordHookHandle(hook(updateOrientationViews).setId(HOOK_UPDATE_ORIENTATION)
+                .intercept(this::interceptUpdateOrientation));
     }
 
     private void hookDeadZone(ClassLoader classLoader) {
         try {
             var classDeadZone = classLoader.loadClass("android.inputmethodservice.navigationbar.DeadZone");
-            var fSizeMin = classDeadZone.getDeclaredField("mSizeMin");
-            fSizeMin.setAccessible(true);
             var methodOnConfigurationChanged = classDeadZone.getDeclaredMethod("onConfigurationChanged", int.class);
-            hook(methodOnConfigurationChanged).intercept(chain -> {
-                var result = chain.proceed();
-                try {
-                    var obj = chain.getThisObject();
-                    if (obj == null) return result;
-                    fSizeMin.setInt(obj, 0);
-                } catch (Exception e) {
-                    log(Log.ERROR, TAG, "hook DeadZone.onConfigurationChanged", e);
-                }
-                return result;
-            });
+            recordHookHandle(hook(methodOnConfigurationChanged).setId(HOOK_DEAD_ZONE)
+                    .intercept(this::interceptDeadZone));
         } catch (Exception e) {
             log(Log.ERROR, TAG, "hook DeadZone", e);
         }
@@ -255,87 +301,28 @@ public class ImeHook extends XposedModule {
     }
 
     private void hookInputMethodManagerService(ClassLoader classLoader)
-            throws NoSuchMethodException, ClassNotFoundException, NoSuchFieldException {
+            throws NoSuchMethodException, ClassNotFoundException {
         var classInputMethodManagerService = classLoader.loadClass("com.android.server.inputmethod.InputMethodManagerService");
-        var methodGetInputMethodNavButtonFlagsLocked = classInputMethodManagerService.getDeclaredMethod("getInputMethodNavButtonFlagsLocked");
-        var fieldImeDrawsImeNavBarRes = classInputMethodManagerService.getDeclaredField("mImeDrawsImeNavBarRes");
-        fieldImeDrawsImeNavBarRes.setAccessible(true);
-        var classOverlayableSystemBooleanResourceWrapper = classLoader.loadClass("com.android.server.inputmethod.OverlayableSystemBooleanResourceWrapper");
-        var fieldValueRefOverlayableSystemBooleanResourceWrapper = classOverlayableSystemBooleanResourceWrapper.getDeclaredField("mValueRef");
-        fieldValueRefOverlayableSystemBooleanResourceWrapper.setAccessible(true);
-        var fieldSettings = classInputMethodManagerService.getDeclaredField("mSettings");
-        fieldSettings.setAccessible(true);
-        var fContext = classInputMethodManagerService.getDeclaredField("mContext");
-        fContext.setAccessible(true);
-        var InputMethodManagerServiceStubClass = classLoader.loadClass("com.android.server.inputmethod.InputMethodManagerServiceStub");
-        var methodInputMethodManagerServiceStubGetInstance = InputMethodManagerServiceStubClass.getDeclaredMethod("getInstance");
-        final String NAV_BAR_MODE_GESTURAL_OVERLAY = "com.android.internal.systemui.navbar.gestural";
-        hook(methodGetInputMethodNavButtonFlagsLocked).intercept(chain -> {
-            try {
-                var mImeDrawsImeNavBarRes = fieldImeDrawsImeNavBarRes.get(chain.getThisObject());
-                var InputMethodManagerServiceImpl = getInvoker(methodInputMethodManagerServiceStubGetInstance).invoke(chain.getThisObject());
-                if (InputMethodManagerServiceImpl != null) {
-                    var methodIsCustomizedInputMethod = InputMethodManagerServiceImpl.getClass().getDeclaredMethod("isCustomizedInputMethod", String.class);
-                    methodIsCustomizedInputMethod.setAccessible(true);
-                    var mSettings = fieldSettings.get(chain.getThisObject());
-                    if (mSettings != null && fContext.get(chain.getThisObject()) instanceof Context mContext) {
-                        var getSelectedInputMethod = mSettings.getClass().getDeclaredMethod("getSelectedInputMethod");
-                        getSelectedInputMethod.setAccessible(true);
-                        var isGesturesNav = Settings.Secure.getInt(mContext.getContentResolver(), "navigation_mode", 2) == 2;
-                        var canImeDrawsImeNavBar = isGesturesNav && getInvoker(methodIsCustomizedInputMethod).invoke(InputMethodManagerServiceImpl,
-                                getSelectedInputMethod.invoke(mSettings)) instanceof Boolean isCustomizedInputMethod && !isCustomizedInputMethod;
-                        try {
-                            if (mContext.getSystemService(Context.OVERLAY_SERVICE) instanceof OverlayManager overlayManager) {
-                                var overlayInfo = HiddenApiBridge.OverlayManager_getOverlayInfo(overlayManager, NAV_BAR_MODE_GESTURAL_OVERLAY, HiddenApiBridge.UserHandle_CURRENT());
-                                if (overlayInfo != null) {
-                                    var enabled = HiddenApiBridge.OverlayInfo_isEnabled(overlayInfo);
-                                    if (enabled != canImeDrawsImeNavBar) {
-                                        HiddenApiBridge.OverlayManager_setEnabled(overlayManager, NAV_BAR_MODE_GESTURAL_OVERLAY, canImeDrawsImeNavBar, HiddenApiBridge.UserHandle_CURRENT());
-                                    }
-                                }
-                            }
-                        } catch (SecurityException | IllegalStateException e) {
-                            log(Log.ERROR, TAG, "Failed to toggle gestural nav overlay", e);
-                        }
-                        if (fieldValueRefOverlayableSystemBooleanResourceWrapper.get(mImeDrawsImeNavBarRes) instanceof AtomicBoolean mImeDrawsImeNavBar) {
-                            mImeDrawsImeNavBar.set(canImeDrawsImeNavBar);
-                        }
-                    }
-                }
-            } catch (IllegalAccessException | InvocationTargetException |
-                     NoSuchMethodException e) {
-                log(Log.ERROR, TAG, "hook getInputMethodNavButtonFlagsLocked", e);
+        Method methodGetInputMethodNavButtonFlagsLocked = null;
+        for (Method method : classInputMethodManagerService.getDeclaredMethods()) {
+            if ("getInputMethodNavButtonFlagsLocked".equals(method.getName())) {
+                methodGetInputMethodNavButtonFlagsLocked = method;
+                break;
             }
-            return chain.proceed();
-        });
+        }
+        if (methodGetInputMethodNavButtonFlagsLocked == null) {
+            throw new NoSuchMethodException("getInputMethodNavButtonFlagsLocked");
+        }
+        recordHookHandle(hook(methodGetInputMethodNavButtonFlagsLocked)
+                .setId(HOOK_NAV_BUTTON_FLAGS).intercept(this::interceptNavButtonFlags));
     }
 
     private void hookInputMethodManagerServiceImpl(ClassLoader classLoader)
             throws NoSuchMethodException, ClassNotFoundException {
         var classInputMethodManagerServiceImpl = classLoader.loadClass("com.android.server.inputmethod.InputMethodManagerServiceImpl");
         var methodIsCallingBetweenCustomIME = classInputMethodManagerServiceImpl.getDeclaredMethod("isCallingBetweenCustomIME", Context.class, int.class, String.class);
-        hook(methodIsCallingBetweenCustomIME).intercept(chain -> {
-            var args = chain.getArgs();
-            var result = chain.proceed();
-            if (result instanceof Boolean isCallingBetweenCustomIME
-                    && !isCallingBetweenCustomIME && args.size() >= 3
-                    && args.get(0) instanceof Context context && args.get(1) instanceof Integer uid) {
-                var imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
-                var currentInputMethodInfo = imm.getCurrentInputMethodInfo();
-                if (currentInputMethodInfo != null) {
-                    var currentInputMethodInfoPackageName = currentInputMethodInfo.getPackageName();
-                    var packagesForQueryingUid = context.getPackageManager().getPackagesForUid(uid);
-                    if (packagesForQueryingUid != null) {
-                        for (var queryingUidPackageName : packagesForQueryingUid) {
-                            if (currentInputMethodInfoPackageName.equals(queryingUidPackageName)) {
-                                return true;
-                            }
-                        }
-                    }
-                }
-            }
-            return result;
-        });
+        recordHookHandle(hook(methodIsCallingBetweenCustomIME).setId(HOOK_CUSTOM_IME_CALLER)
+                .intercept(this::interceptCustomImeCaller));
     }
 
     private void hookInputMethodBottomManager(ClassLoader classLoader) throws
@@ -344,37 +331,503 @@ public class ImeHook extends XposedModule {
         var classInputMethodModuleManager = classLoader.loadClass("android.inputmethodservice.InputMethodModuleManager");
         var methodLoadDex = classInputMethodModuleManager.getDeclaredMethod("loadDex",
                 ClassLoader.class, String.class);
-        hook(methodLoadDex).intercept(chain -> {
-            var result = chain.proceed();
-            try {
-                var args = chain.getArgs();
-                if (!args.isEmpty() && args.get(0) instanceof ClassLoader imeModuleClassLoader) {
-                    var classInputMethodBottomManager = imeModuleClassLoader.loadClass("com.miui.inputmethod.InputMethodBottomManager");
-                    var methodGetSupportIme = classInputMethodBottomManager.getDeclaredMethod("getSupportIme");
-                    var classBottomViewHelper = imeModuleClassLoader.loadClass("com.miui.inputmethod.InputMethodBottomManager$BottomViewHelper");
-                    var mBottomViewHelperImm = classBottomViewHelper.getDeclaredField("mImm");
-                    mBottomViewHelperImm.setAccessible(true);
-                    var sBottomViewHelper = classInputMethodBottomManager.getDeclaredField("sBottomViewHelper");
-                    sBottomViewHelper.setAccessible(true);
-                    module.hook(methodGetSupportIme).intercept(chain1 -> {
-                        try {
-                            var instanceBottomViewHelper = sBottomViewHelper.get(chain1.getThisObject());
-                            if (instanceBottomViewHelper != null) {
-                                if (mBottomViewHelperImm.get(instanceBottomViewHelper) instanceof InputMethodManager inputMethodManager) {
-                                    return inputMethodManager.getEnabledInputMethodList();
-                                }
-                            }
-                        } catch (IllegalAccessException e) {
-                            log(Log.ERROR, TAG, "hook getSupportIme", e);
-                        }
-                        return chain1.proceed();
-                    });
-                }
-            } catch (NoSuchFieldException | ClassNotFoundException |
-                     NoSuchMethodException e) {
-                log(Log.ERROR, TAG, "hook loadDex", e);
+        recordHookHandle(hook(methodLoadDex).setId(HOOK_LOAD_BOTTOM_DEX)
+                .intercept(this::interceptLoadBottomDex));
+    }
+
+    private void backfillHotReloadHooks(XposedModuleInterface.HotReloadedParam param,
+                                        ClassLoader classLoader,
+                                        Set<String> installedHookIds) {
+        if (classLoader == null) {
+            log(Log.WARN, TAG, "Cannot backfill hot reload hooks without a class loader");
+            return;
+        }
+        if (param.isSystemServer() || "system".equals(param.getProcessName())) {
+            backfillHook(HOOK_NAV_BUTTON_FLAGS, installedHookIds,
+                    () -> hookInputMethodManagerService(classLoader));
+            backfillHook(HOOK_CUSTOM_IME_CALLER, installedHookIds,
+                    () -> hookInputMethodManagerServiceImpl(classLoader));
+            return;
+        }
+        backfillHook(HOOK_HIDE_GESTURAL_BUTTONS, installedHookIds,
+                () -> hookInputMethodService(classLoader));
+        backfillHook(HOOK_CAPTION_BAR_HEIGHT, installedHookIds,
+                () -> hookNavigationBarController(classLoader));
+        try {
+            if (usesStandaloneNavigationBarController(classLoader)) {
+                backfillHook(HOOK_INPUT_VIEW_BOTTOM_INSET, installedHookIds,
+                        () -> hookInputViewBottomInset(classLoader));
+                backfillHook(HOOK_DISPATCH_INPUT_VIEW_INSETS, installedHookIds,
+                        () -> hookInputViewInsetsDispatch(classLoader));
+                backfillHook(HOOK_CAPTION_BAR_INSETS_HEIGHT, installedHookIds,
+                        () -> hookCaptionBarInsetsHeight(classLoader));
+                backfillHook(HOOK_SYSTEM_INSETS_HEIGHT, installedHookIds,
+                        () -> hookNavigationBarSystemInsets(classLoader));
             }
-            return result;
-        });
+        } catch (ClassNotFoundException e) {
+            log(Log.WARN, TAG, "Unable to detect NavigationBarController generation", e);
+        }
+        backfillHook(HOOK_INFLATE_NAV_LAYOUT, installedHookIds,
+                () -> hookNavigationBarInflaterView(classLoader));
+        backfillHook(HOOK_UPDATE_ORIENTATION, installedHookIds,
+                () -> hookNavigationBarView(classLoader));
+        backfillHook(HOOK_DEAD_ZONE, installedHookIds,
+                () -> hookDeadZone(classLoader));
+        backfillHook(HOOK_LOAD_BOTTOM_DEX, installedHookIds,
+                () -> hookInputMethodBottomManager(classLoader));
+    }
+
+    private void backfillHook(String hookId, Set<String> installedHookIds,
+                              ThrowingRunnable installer) {
+        if (installedHookIds.contains(hookId)) return;
+        try {
+            installer.run();
+            installedHookIds.add(hookId);
+            log(Log.INFO, TAG, "Backfilled hot reload hook " + hookId);
+        } catch (Throwable throwable) {
+            log(Log.WARN, TAG, "Unable to backfill hot reload hook " + hookId, throwable);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ThrowingRunnable {
+        void run() throws Throwable;
+    }
+
+    private synchronized void recordHookHandle(XposedInterface.HookHandle handle) {
+        hookHandles.add(handle);
+    }
+
+    private synchronized void initializeNavBarLayoutPreferences() {
+        releaseNavBarLayoutPreferences();
+        var preferences = getRemotePreferences("conf");
+        navBarLayoutHandle.set(preferences.getString("nav_bar_layout_handle", ""));
+        SharedPreferences.OnSharedPreferenceChangeListener listener = (prefs, key) -> {
+            if ("nav_bar_layout_handle".equals(key)) {
+                String layout = prefs.getString(key, "");
+                navBarLayoutHandle.set(layout);
+                refreshNavBarLayouts(layout);
+            }
+        };
+        preferences.registerOnSharedPreferenceChangeListener(listener);
+        navBarPreferences = preferences;
+        navBarPreferenceListener = listener;
+    }
+
+    private synchronized void releaseNavBarLayoutPreferences() {
+        if (navBarPreferences != null && navBarPreferenceListener != null) {
+            navBarPreferences.unregisterOnSharedPreferenceChangeListener(navBarPreferenceListener);
+        }
+        navBarPreferences = null;
+        navBarPreferenceListener = null;
+    }
+
+    private static String identifyHook(Executable executable) {
+        if (executable == null) return null;
+        String owner = executable.getDeclaringClass().getName();
+        return switch (owner + "#" + executable.getName()) {
+            case "android.inputmethodservice.InputMethodService#hideImeRenderGesturalNavButtons" ->
+                    HOOK_HIDE_GESTURAL_BUTTONS;
+            case "android.inputmethodservice.NavigationBarController$Impl#getImeCaptionBarHeight",
+                 "android.inputmethodservice.NavigationBarController#getImeCaptionBarHeight" ->
+                    HOOK_CAPTION_BAR_HEIGHT;
+            case "android.view.InsetsController#setImeCaptionBarInsetsHeight" ->
+                    HOOK_CAPTION_BAR_INSETS_HEIGHT;
+            case "android.inputmethodservice.NavigationBarController#getSystemInsets" ->
+                    HOOK_SYSTEM_INSETS_HEIGHT;
+            case "android.inputmethodservice.InputMethodService#setInputView" ->
+                    HOOK_INPUT_VIEW_BOTTOM_INSET;
+            case "android.view.View#dispatchApplyWindowInsets" ->
+                    HOOK_DISPATCH_INPUT_VIEW_INSETS;
+            case "android.inputmethodservice.navigationbar.NavigationBarInflaterView#inflateLayout" ->
+                    HOOK_INFLATE_NAV_LAYOUT;
+            case "android.inputmethodservice.navigationbar.NavigationBarView#updateOrientationViews" ->
+                    HOOK_UPDATE_ORIENTATION;
+            case "android.inputmethodservice.navigationbar.DeadZone#onConfigurationChanged" ->
+                    HOOK_DEAD_ZONE;
+            case "com.android.server.inputmethod.InputMethodManagerService#getInputMethodNavButtonFlagsLocked" ->
+                    HOOK_NAV_BUTTON_FLAGS;
+            case "com.android.server.inputmethod.InputMethodManagerServiceImpl#isCallingBetweenCustomIME" ->
+                    HOOK_CUSTOM_IME_CALLER;
+            case "android.inputmethodservice.InputMethodModuleManager#loadDex" ->
+                    HOOK_LOAD_BOTTOM_DEX;
+            case "com.miui.inputmethod.InputMethodBottomManager#getSupportIme" ->
+                    HOOK_SUPPORTED_IME_LIST;
+            default -> null;
+        };
+    }
+
+    private XposedInterface.Hooker createHotReloadHooker(String hookId) {
+        if (hookId == null) return null;
+        return switch (hookId) {
+            case HOOK_HIDE_GESTURAL_BUTTONS -> this::interceptHideGesturalButtons;
+            case HOOK_CAPTION_BAR_HEIGHT -> this::interceptCaptionBarHeight;
+            case HOOK_CAPTION_BAR_INSETS_HEIGHT -> this::interceptCaptionBarInsetsHeight;
+            case HOOK_SYSTEM_INSETS_HEIGHT -> this::interceptNavigationBarSystemInsets;
+            case HOOK_INPUT_VIEW_BOTTOM_INSET -> this::interceptInputViewBottomInset;
+            case HOOK_DISPATCH_INPUT_VIEW_INSETS -> this::interceptInputViewInsetsDispatch;
+            case HOOK_INFLATE_NAV_LAYOUT -> this::interceptInflateNavLayout;
+            case HOOK_UPDATE_ORIENTATION -> this::interceptUpdateOrientation;
+            case HOOK_DEAD_ZONE -> this::interceptDeadZone;
+            case HOOK_NAV_BUTTON_FLAGS -> this::interceptNavButtonFlags;
+            case HOOK_CUSTOM_IME_CALLER -> this::interceptCustomImeCaller;
+            case HOOK_LOAD_BOTTOM_DEX -> this::interceptLoadBottomDex;
+            case HOOK_SUPPORTED_IME_LIST -> this::interceptSupportedImeList;
+            default -> null;
+        };
+    }
+
+    private Object interceptHideGesturalButtons(XposedInterface.Chain chain) throws Throwable {
+        try {
+            var serviceClass = chain.getExecutable().getDeclaringClass();
+            var stubClass = serviceClass.getClassLoader().loadClass(
+                    "android.inputmethodservice.InputMethodServiceStub");
+            var getInstance = stubClass.getDeclaredMethod("getInstance");
+            var injector = getInvoker(getInstance).invoke(chain.getThisObject());
+            if (injector != null) {
+                var isImeSupport = injector.getClass().getDeclaredMethod("isImeSupport", Context.class);
+                isImeSupport.setAccessible(true);
+                if (chain.getThisObject() instanceof InputMethodService inputMethodService
+                        && getInvoker(isImeSupport).invoke(injector,
+                        inputMethodService.getApplicationContext()) instanceof Boolean supported
+                        && !supported) {
+                    return false;
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload hideImeRenderGesturalNavButtons", e);
+        }
+        return chain.proceed();
+    }
+
+    private Object interceptCaptionBarHeight(XposedInterface.Chain chain) throws Throwable {
+        try {
+            Object owner = chain.getThisObject();
+            var ownerClass = chain.getExecutable().getDeclaringClass();
+            var drawsNavBar = ownerClass.getDeclaredField("mImeDrawsImeNavBar");
+            var service = ownerClass.getDeclaredField("mService");
+            drawsNavBar.setAccessible(true);
+            service.setAccessible(true);
+            boolean shouldShow = !chain.getArgs().isEmpty()
+                    && chain.getArg(0) instanceof Boolean value
+                    ? value : drawsNavBar.getBoolean(owner);
+            if (shouldShow && service.get(owner) instanceof InputMethodService inputMethodService) {
+                int height = dpToPx(48, inputMethodService.getResources());
+                return height;
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload getImeCaptionBarHeight", e);
+        }
+        return chain.proceed();
+    }
+
+    private Object interceptCaptionBarInsetsHeight(XposedInterface.Chain chain) throws Throwable {
+        if (!chain.getArgs().isEmpty() && chain.getArg(0) instanceof Integer height
+                && height > 0) {
+            int target = dpToPx(48, Resources.getSystem());
+            if (height != target) {
+                Object[] args = chain.getArgs().toArray();
+                args[0] = target;
+                return chain.proceed(args);
+            }
+        }
+        return chain.proceed();
+    }
+
+    private Object interceptNavigationBarSystemInsets(XposedInterface.Chain chain)
+            throws Throwable {
+        Object result = chain.proceed();
+        if (!(result instanceof Insets insets)) return result;
+        try {
+            Object owner = chain.getThisObject();
+            var serviceField = chain.getExecutable().getDeclaringClass()
+                    .getDeclaredField("mService");
+            serviceField.setAccessible(true);
+            if (serviceField.get(owner) instanceof InputMethodService inputMethodService) {
+                int height = dpToPx(48, inputMethodService.getResources());
+                return Insets.of(insets.left, insets.top, insets.right,
+                        Math.max(insets.bottom, height));
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload NavigationBarController.getSystemInsets", e);
+        }
+        return result;
+    }
+
+    private static final WeakHashMap<View, Boolean> INPUT_VIEWS = new WeakHashMap<>();
+
+    private Object interceptInputViewBottomInset(XposedInterface.Chain chain) throws Throwable {
+        Object result = chain.proceed();
+        if (!chain.getArgs().isEmpty() && chain.getArg(0) instanceof View inputView) {
+            INPUT_VIEWS.put(inputView, Boolean.TRUE);
+            inputView.requestApplyInsets();
+        }
+        return result;
+    }
+
+    private Object interceptInputViewInsetsDispatch(XposedInterface.Chain chain) throws Throwable {
+        if (chain.getThisObject() instanceof View view && INPUT_VIEWS.containsKey(view)
+                && !chain.getArgs().isEmpty()
+                && chain.getArg(0) instanceof WindowInsets insets) {
+            Insets navigationBars = insets.getInsets(WindowInsets.Type.navigationBars());
+            Insets captionBar = insets.getInsets(WindowInsets.Type.captionBar());
+            int bottom = Math.max(navigationBars.bottom, captionBar.bottom);
+            if (bottom != navigationBars.bottom) {
+                WindowInsets mergedInsets = new WindowInsets.Builder(insets)
+                        .setInsets(WindowInsets.Type.navigationBars(), Insets.of(
+                                navigationBars.left, navigationBars.top,
+                                navigationBars.right, bottom))
+                        .build();
+                Object[] args = chain.getArgs().toArray();
+                args[0] = mergedInsets;
+                return chain.proceed(args);
+            }
+        }
+        return chain.proceed();
+    }
+
+    private Object interceptInflateNavLayout(XposedInterface.Chain chain) throws Throwable {
+        Object owner = chain.getThisObject();
+        if (owner instanceof View inflaterView) {
+            synchronized (ACTIVE_NAV_BAR_LAYOUTS) {
+                if (!ACTIVE_NAV_BAR_LAYOUTS.containsKey(inflaterView)) {
+                    ACTIVE_NAV_BAR_LAYOUTS.put(inflaterView,
+                            chain.getArg(0) instanceof String layout ? layout : null);
+                }
+            }
+        }
+        if (chain.getArg(0) instanceof String && !navBarLayoutHandle.get().isBlank()) {
+            Object[] args = chain.getArgs().toArray();
+            args[0] = navBarLayoutHandle.get();
+            return chain.proceed(args);
+        }
+        return chain.proceed();
+    }
+
+    private void refreshNavBarLayouts(String configuredLayout) {
+        List<View> views = new ArrayList<>();
+        List<String> defaultLayouts = new ArrayList<>();
+        synchronized (ACTIVE_NAV_BAR_LAYOUTS) {
+            ACTIVE_NAV_BAR_LAYOUTS.forEach((view, defaultLayout) -> {
+                views.add(view);
+                defaultLayouts.add(defaultLayout);
+            });
+        }
+        for (int index = 0; index < views.size(); index++) {
+            View view = views.get(index);
+            String defaultLayout = defaultLayouts.get(index);
+            view.post(() -> reinflateNavBarLayout(view,
+                    configuredLayout.isBlank() ? defaultLayout : configuredLayout));
+        }
+    }
+
+    private void reinflateNavBarLayout(View view, String layout) {
+        if (!view.isAttachedToWindow()) return;
+        try {
+            Class<?> inflaterClass = view.getClass();
+            Method clearViews = inflaterClass.getDeclaredMethod("clearViews");
+            Method inflateLayout = inflaterClass.getDeclaredMethod("inflateLayout", String.class);
+            clearViews.setAccessible(true);
+            inflateLayout.setAccessible(true);
+            getInvoker(clearViews).invoke(view);
+            getInvoker(inflateLayout).invoke(view, layout);
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "refresh NavigationBarInflaterView layout", e);
+        }
+    }
+
+    private Object interceptUpdateOrientation(XposedInterface.Chain chain) throws Throwable {
+        Object result = chain.proceed();
+        Object owner = chain.getThisObject();
+        if (owner == null) return result;
+        try {
+            var horizontal = chain.getExecutable().getDeclaringClass().getDeclaredField("mHorizontal");
+            horizontal.setAccessible(true);
+            if (horizontal.get(owner) instanceof View horizontalView) {
+                int shadow = dpToPx(4, horizontalView.getResources());
+                horizontalView.setOnApplyWindowInsetsListener((view, insets) -> {
+                    var base = BASE_PADDINGS.computeIfAbsent(view, value -> new int[]{
+                            value.getPaddingLeft() + shadow, value.getPaddingTop(),
+                            value.getPaddingRight() + shadow, value.getPaddingBottom()
+                    });
+                    var left = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_LEFT);
+                    var right = insets.getRoundedCorner(RoundedCorner.POSITION_BOTTOM_RIGHT);
+                    int leftRadius = left != null ? left.getRadius() : 0;
+                    int rightRadius = right != null ? right.getRadius() : 0;
+                    view.setPadding(leftRadius > 0 ? leftRadius - base[0] : base[0], base[1],
+                            rightRadius > 0 ? rightRadius - base[2] : base[2], base[3]);
+                    return insets;
+                });
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload updateOrientationViews", e);
+        }
+        return result;
+    }
+
+    private Object interceptDeadZone(XposedInterface.Chain chain) throws Throwable {
+        Object result = chain.proceed();
+        try {
+            var sizeMin = chain.getExecutable().getDeclaringClass().getDeclaredField("mSizeMin");
+            sizeMin.setAccessible(true);
+            if (chain.getThisObject() != null) sizeMin.setInt(chain.getThisObject(), 0);
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload DeadZone.onConfigurationChanged", e);
+        }
+        return result;
+    }
+
+    private Object interceptNavButtonFlags(XposedInterface.Chain chain) throws Throwable {
+        if (!chain.getArgs().isEmpty() && chain.getArg(0) != null) {
+            try {
+                Object owner = chain.getThisObject();
+                Object userData = chain.getArg(0);
+                var ownerClass = chain.getExecutable().getDeclaringClass();
+                var contextField = ownerClass.getDeclaredField("mContext");
+                var bindingField = userData.getClass().getDeclaredField("mBindingController");
+                var drawsNavBarField = userData.getClass().getDeclaredField("mImeDrawsNavBar");
+                contextField.setAccessible(true);
+                bindingField.setAccessible(true);
+                drawsNavBarField.setAccessible(true);
+                Object bindingController = bindingField.get(userData);
+                var getSelectedImeId = bindingController.getClass().getDeclaredMethod(
+                        "getSelectedImeId");
+                getSelectedImeId.setAccessible(true);
+                Object selectedImeId = getInvoker(getSelectedImeId).invoke(bindingController);
+                var stubClass = ownerClass.getClassLoader().loadClass(
+                        "com.android.server.inputmethod.InputMethodManagerServiceStub");
+                var getInstance = stubClass.getDeclaredMethod("getInstance");
+                Object implementation = getInvoker(getInstance).invoke(owner);
+                if (implementation != null && selectedImeId instanceof String imeId
+                        && contextField.get(owner) instanceof Context context) {
+                    var isCustomized = implementation.getClass().getDeclaredMethod(
+                            "isCustomizedInputMethod", String.class);
+                    isCustomized.setAccessible(true);
+                    boolean gestures = Settings.Secure.getInt(
+                            context.getContentResolver(), "navigation_mode", 2) == 2;
+                    boolean customized = getInvoker(isCustomized).invoke(implementation, imeId)
+                            instanceof Boolean value && value;
+                    if (gestures && !customized
+                            && drawsNavBarField.get(userData) instanceof AtomicBoolean drawsNavBar) {
+                        drawsNavBar.set(true);
+                    }
+                }
+            } catch (ReflectiveOperationException e) {
+                log(Log.ERROR, TAG, "Android 17 getInputMethodNavButtonFlagsLocked", e);
+            }
+            return chain.proceed();
+        }
+        try {
+            Object owner = chain.getThisObject();
+            var ownerClass = chain.getExecutable().getDeclaringClass();
+            var drawsNavBarResource = ownerClass.getDeclaredField("mImeDrawsImeNavBarRes");
+            var settingsField = ownerClass.getDeclaredField("mSettings");
+            var contextField = ownerClass.getDeclaredField("mContext");
+            drawsNavBarResource.setAccessible(true);
+            settingsField.setAccessible(true);
+            contextField.setAccessible(true);
+            var wrapperClass = ownerClass.getClassLoader().loadClass(
+                    "com.android.server.inputmethod.OverlayableSystemBooleanResourceWrapper");
+            var valueReference = wrapperClass.getDeclaredField("mValueRef");
+            valueReference.setAccessible(true);
+            var stubClass = ownerClass.getClassLoader().loadClass(
+                    "com.android.server.inputmethod.InputMethodManagerServiceStub");
+            var getInstance = stubClass.getDeclaredMethod("getInstance");
+            Object implementation = getInvoker(getInstance).invoke(owner);
+            Object settings = settingsField.get(owner);
+            if (implementation != null && settings != null
+                    && contextField.get(owner) instanceof Context context) {
+                var isCustomized = implementation.getClass().getDeclaredMethod(
+                        "isCustomizedInputMethod", String.class);
+                var getSelected = settings.getClass().getDeclaredMethod("getSelectedInputMethod");
+                isCustomized.setAccessible(true);
+                getSelected.setAccessible(true);
+                boolean gestures = Settings.Secure.getInt(
+                        context.getContentResolver(), "navigation_mode", 2) == 2;
+                boolean canDraw = gestures
+                        && getInvoker(isCustomized).invoke(implementation,
+                        getSelected.invoke(settings)) instanceof Boolean customized
+                        && !customized;
+                try {
+                    if (context.getSystemService(Context.OVERLAY_SERVICE)
+                            instanceof OverlayManager overlayManager) {
+                        String overlay = "com.android.internal.systemui.navbar.gestural";
+                        var info = HiddenApiBridge.OverlayManager_getOverlayInfo(overlayManager,
+                                overlay, HiddenApiBridge.UserHandle_CURRENT());
+                        if (info != null && HiddenApiBridge.OverlayInfo_isEnabled(info) != canDraw) {
+                            HiddenApiBridge.OverlayManager_setEnabled(overlayManager, overlay,
+                                    canDraw, HiddenApiBridge.UserHandle_CURRENT());
+                        }
+                    }
+                } catch (SecurityException | IllegalStateException e) {
+                    log(Log.ERROR, TAG, "Failed to toggle gestural nav overlay", e);
+                }
+                Object wrapper = drawsNavBarResource.get(owner);
+                if (valueReference.get(wrapper) instanceof AtomicBoolean value) {
+                    value.set(canDraw);
+                }
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload getInputMethodNavButtonFlagsLocked", e);
+        }
+        return chain.proceed();
+    }
+
+    private Object interceptCustomImeCaller(XposedInterface.Chain chain) throws Throwable {
+        Object result = chain.proceed();
+        var args = chain.getArgs();
+        if (result instanceof Boolean customized && !customized && args.size() >= 3
+                && args.get(0) instanceof Context context && args.get(1) instanceof Integer uid) {
+            var manager = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+            var current = manager.getCurrentInputMethodInfo();
+            if (current != null) {
+                String[] packages = context.getPackageManager().getPackagesForUid(uid);
+                if (packages != null) {
+                    for (String packageName : packages) {
+                        if (current.getPackageName().equals(packageName)) return true;
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private Object interceptLoadBottomDex(XposedInterface.Chain chain) throws Throwable {
+        Object result = chain.proceed();
+        try {
+            if (!chain.getArgs().isEmpty() && chain.getArg(0) instanceof ClassLoader classLoader) {
+                installSupportedImeListHook(classLoader);
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload loadDex", e);
+        }
+        return result;
+    }
+
+    private void installSupportedImeListHook(ClassLoader classLoader)
+            throws ClassNotFoundException, NoSuchMethodException {
+        var managerClass = classLoader.loadClass("com.miui.inputmethod.InputMethodBottomManager");
+        var getSupportIme = managerClass.getDeclaredMethod("getSupportIme");
+        recordHookHandle(hook(getSupportIme).setId(HOOK_SUPPORTED_IME_LIST)
+                .intercept(this::interceptSupportedImeList));
+    }
+
+    private Object interceptSupportedImeList(XposedInterface.Chain chain) throws Throwable {
+        try {
+            var managerClass = chain.getExecutable().getDeclaringClass();
+            var helperClass = managerClass.getClassLoader().loadClass(
+                    "com.miui.inputmethod.InputMethodBottomManager$BottomViewHelper");
+            var helperImm = helperClass.getDeclaredField("mImm");
+            var staticHelper = managerClass.getDeclaredField("sBottomViewHelper");
+            helperImm.setAccessible(true);
+            staticHelper.setAccessible(true);
+            Object helper = staticHelper.get(chain.getThisObject());
+            if (helper != null && helperImm.get(helper) instanceof InputMethodManager manager) {
+                return manager.getEnabledInputMethodList();
+            }
+        } catch (ReflectiveOperationException e) {
+            log(Log.ERROR, TAG, "hot reload getSupportIme", e);
+        }
+        return chain.proceed();
     }
 }

--- a/MiAOSPIME/src/main/resources/META-INF/xposed/module.prop
+++ b/MiAOSPIME/src/main/resources/META-INF/xposed/module.prop
@@ -1,3 +1,4 @@
-minApiVersion=101
-targetApiVersion=101
+minApiVersion=102
+targetApiVersion=102
 staticScope=false
+autoHotReload=true

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.android.application' version '9.1.0' apply false
+    id 'com.android.application' version '9.3.1' apply false
     id 'org.lsposed.lsplugin.jgit' version "1.1"
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Xiaomi Android 17 changes

  - `NavigationBarController$Impl` was replaced by `NavigationBarController`.
  - `IS_INTERNATIONAL_BUILD` became final.
  - `getInputMethodNavButtonFlagsLocked()` now receives `UserData`.
  - IME navigation buttons and caption-bar Insets no longer use the same height.

  ## Android 17 fixes

  - Support the new controller and `UserData` structures.
  - Return the required result directly instead of modifying the final field.
  - Restore the 48 dp navigation-button and caption-bar height.
  - Propagate caption-bar Insets to third-party IMEs such as Gboard.

  ## HyperOS 3/4 compatibility

  - Detect the controller implementation at runtime.
  - Keep the original hook path for HyperOS 3.
  - Enable the new Android 17 path only on HyperOS 4.

  ## libxposed API 102

  - Update API and service dependencies to 102.
  - Add stable hook IDs and retain hook handles.
  - Replace and backfill hooks during automatic hot reload.
  - Installing a new build no longer requires a reboot.

  ## Navigation button settings

  - Track the active navigation-bar layout.
  - Re-inflate it when the left or right function-key setting changes.
  - Changes now apply without force-stopping the input method.
